### PR TITLE
use 64-bit types explicitely, fix ns calculation

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -12,12 +12,12 @@ struct tdsTypeDAQmxRawData <: TDMSUnimplementedType end
 
 abstract type TDMSType end
 struct TimeStamp <: TDMSType
-    seconds::Int
-    fractions::UInt
+    seconds::Int64
+    fractions::UInt64
 end
 const epoch=TimeDate(1904,1,1)
 function TimeDate(x::TimeStamp)
-    ns = round(x.fractions*(2.0^-64),digits=9)
+    ns = round(x.fractions*(2.0^-64)*1e9)
     epoch + Second(x.seconds) + Nanosecond(ns)
 end
 function Base.:+(x::T,y::T) where {T<:TimeStamp}
@@ -36,7 +36,7 @@ Base.show(ts::TimeStamp) = show(TimeDate(ts))
 
 function Base.:read(s::IO, ::Type{TimeStamp})
     fractions=read(s,UInt64)
-    seconds=read(s, Int)
+    seconds=read(s, Int64)
     TimeStamp(seconds,fractions)
 end
 


### PR DESCRIPTION
Int is Int32 in 32-bit systems, Int64 in 64-bit systems.  According to http://www.ni.com/product-documentation/5696/en/ , seconds signed 64-bit int, fractions unsigned 64-int.

`Nanosecond` argument should not contain decimals. Fix the scaling.
Before this, loading a tdms-file with InitTimeStamp other than 0 fails with error like this
`ERROR: InexactError: Int64(0.90372025)`