### PR TITLE
fixed raw data being dropped

### DIFF
--- a/src/TDMSReader.jl
+++ b/src/TDMSReader.jl
@@ -12,6 +12,7 @@ const _example_DAQmx=(@__DIR__) * "\\..\\test\\example_files\\DAQmx example.tdms
 export readtdms
 
 readtdms() = readtdms(_example_tdms)
+
 function readtdms(fn::AbstractString)
     s = open(fn)
     f=File()
@@ -29,7 +30,42 @@ function readtdms(fn::AbstractString)
         end
     end
     close(s)
-    f
+    return f
+end
+
+function readseginfo(fn::AbstractString)
+    #STILL COULD USE SOME WORK HERE TO MAKE IT CLEAN AND NEAT
+    s = open(fn)
+    f=File()
+    objdict=ObjDict()
+    tdmsSeg = OrderedDict()
+    lead_size = 28 #lead in is 28 bytes
+    segCnt = 0
+    while !eof(s)
+        startPos = position(s)
+        (toc,nextsegmentoffset,rawdataoffset)=readleadin(s)
+        if toc.kTocNewObjList
+            empty!(objdict.current)
+        end
+
+        nobj = read(s, UInt32)
+        seek(s,startPos+lead_size)
+        if toc.kTocMetaData
+            readmetadata!(f, objdict, s)
+        end
+        if toc.kTocRawData
+            #readrawdata!(objdict, nextsegmentoffset-rawdataoffset, s)
+        end
+        nextsegmentPos = Int64(startPos+nextsegmentoffset+lead_size)
+        dataPos = Int64(startPos+lead_size+rawdataoffset)
+        rawdatasize = nextsegmentoffset-rawdataoffset
+        tdmsTmp = SegInfo(startPos,toc,nextsegmentPos,dataPos,nobj,rawdatasize)
+        segCnt +=1
+        tdmsSeg[string("seg",segCnt)] = tdmsTmp
+        seek(s,nextsegmentPos)
+    end
+    close(s)
+    return f,objdict,tdmsSeg
 end
 
 function readleadin(s::IO)
@@ -92,10 +128,13 @@ function readobj!(f::File, objdict::ObjDict, s::IO)
             hasrawdata && throw(ErrorException("TDMS Group should not have raw data"))
             readprop!(g.props,s)
         else # Is  a Channel
-            chan=if haskey(g.channels,channel)
-                g[channel]
+            if haskey(g.channels,channel)
+                if hasnewchunk && eltype(g[channel].data)==Nothing #need to replace existing channel if created without having data
+                    setindex!(g.channels,TDMSReader.Channel{T}(g[channel].props),channel) #update channel to actual data type
+                end
+                chan = g[channel]
             else
-                if hasrawdata
+                chan=if hasrawdata
                     get!(g.channels, channel, TDMSReader.Channel{T}())
                 else
                     get!(g.channels, channel, TDMSReader.Channel{Nothing}())

--- a/src/TDMSReader.jl
+++ b/src/TDMSReader.jl
@@ -12,7 +12,6 @@ const _example_DAQmx=(@__DIR__) * "\\..\\test\\example_files\\DAQmx example.tdms
 export readtdms
 
 readtdms() = readtdms(_example_tdms)
-
 function readtdms(fn::AbstractString)
     s = open(fn)
     f=File()
@@ -30,42 +29,7 @@ function readtdms(fn::AbstractString)
         end
     end
     close(s)
-    return f
-end
-
-function readseginfo(fn::AbstractString)
-    #STILL COULD USE SOME WORK HERE TO MAKE IT CLEAN AND NEAT
-    s = open(fn)
-    f=File()
-    objdict=ObjDict()
-    tdmsSeg = OrderedDict()
-    lead_size = 28 #lead in is 28 bytes
-    segCnt = 0
-    while !eof(s)
-        startPos = position(s)
-        (toc,nextsegmentoffset,rawdataoffset)=readleadin(s)
-        if toc.kTocNewObjList
-            empty!(objdict.current)
-        end
-
-        nobj = read(s, UInt32)
-        seek(s,startPos+lead_size)
-        if toc.kTocMetaData
-            readmetadata!(f, objdict, s)
-        end
-        if toc.kTocRawData
-            #readrawdata!(objdict, nextsegmentoffset-rawdataoffset, s)
-        end
-        nextsegmentPos = Int64(startPos+nextsegmentoffset+lead_size)
-        dataPos = Int64(startPos+lead_size+rawdataoffset)
-        rawdatasize = nextsegmentoffset-rawdataoffset
-        tdmsTmp = SegInfo(startPos,toc,nextsegmentPos,dataPos,nobj,rawdatasize)
-        segCnt +=1
-        tdmsSeg[string("seg",segCnt)] = tdmsTmp
-        seek(s,nextsegmentPos)
-    end
-    close(s)
-    return f,objdict,tdmsSeg
+    f
 end
 
 function readleadin(s::IO)
@@ -128,13 +92,10 @@ function readobj!(f::File, objdict::ObjDict, s::IO)
             hasrawdata && throw(ErrorException("TDMS Group should not have raw data"))
             readprop!(g.props,s)
         else # Is  a Channel
-            if haskey(g.channels,channel)
-                if hasnewchunk && eltype(g[channel].data)==Nothing #need to replace existing channel if created without having data
-                    setindex!(g.channels,TDMSReader.Channel{T}(g[channel].props),channel) #update channel to actual data type
-                end
-                chan = g[channel]
+            chan=if haskey(g.channels,channel)
+                g[channel]
             else
-                chan=if hasrawdata
+                if hasrawdata
                     get!(g.channels, channel, TDMSReader.Channel{T}())
                 else
                     get!(g.channels, channel, TDMSReader.Channel{Nothing}())

--- a/src/types.jl
+++ b/src/types.jl
@@ -71,6 +71,7 @@ struct Channel{T}
     props::OrderedDict{String,Any}
 
     Channel{T}() where {T} = new(Vector{T}(),OrderedDict{String,Any}())
+    Channel{T}(props) where {T} = new(Vector{T}(),props) #already have props 
 end
 ==(a::TDMSReader.Channel,b::TDMSReader.Channel) = (a.props == b.props) && (a.data == b.data)
 
@@ -134,4 +135,13 @@ function Base.:getindex(g::Group, channel::Union{Integer,AbstractString})
     else
         g.channels[channel]
     end
+end
+
+struct SegInfo
+    position::Int64
+    toc::ToC
+    nextsegmentposition::Int64
+    rawdataposition::Int64
+    nobj::Int64
+    rawdatasize::Int64
 end


### PR DESCRIPTION
Changes should solve #4 checking if existing channel was initialized without having data first when there actually is data. Replaces the existing channel accordingly and stores already read props too. 

An additional function and struct was also created to read only the metadata and return an outline and segment information. This was initially used for other work arounds to the initial issue. The function readseginfo is a WIP and could probably be shortened to provide only segment information though if desired. 